### PR TITLE
Use recursive function for parallelism

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,10 +121,10 @@ func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate
 	ch = s3wrapper.ListRecurse(b, prefix, searchDepth, isRecursive)
 
 	var wg sync.WaitGroup
+	writer := bufio.NewWriter(os.Stdout)
 	for i := 0; i < runtime.NumCPU(); i++ {
 		wg.Add(1)
 		go func() {
-			writer := bufio.NewWriter(os.Stdout)
 			for k := range ch {
 				if k.Size < 0 {
 					writer.WriteString(fmt.Sprintf("%10s s3://%s/%s\n", "DIR", bucket, k.Key))

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate
 	b := GetBucket(bucket)
 
 	var ch <-chan s3.Key
-	ch = s3wrapper.ListRecurse(b, prefix, searchDepth, isRecursive)
+	ch = s3wrapper.FastList(b, prefix, searchDepth, isRecursive)
 
 	for k := range ch {
 		if k.Size < 0 {
@@ -165,7 +165,7 @@ func Del(prefixes []string, searchDepth int, isRecursive bool, logger *log.Logge
 				if keyExists {
 					keys <- prefix
 				} else if *delRecurse {
-					for key := range s3wrapper.ListRecurse(b, prefix, searchDepth, true) {
+					for key := range s3wrapper.FastList(b, prefix, searchDepth, true) {
 						keys <- key.Key
 					}
 
@@ -271,7 +271,7 @@ func Get(prefixes []string, searchDepth int, logger *log.Logger) {
 				ogPrefix := strings.Join(keyParts[0:len(keyParts)-1], "/") + "/"
 				getRequests <- GetRequest{Key: prefix, OriginalPrefix: ogPrefix}
 			} else {
-				for key := range s3wrapper.ListRecurse(b, prefix, searchDepth, true) {
+				for key := range s3wrapper.FastList(b, prefix, searchDepth, true) {
 					getRequests <- GetRequest{Key: key.Key, OriginalPrefix: prefix}
 				}
 
@@ -358,7 +358,7 @@ func Stream(prefixes []string, searchDepth int, keyRegex string, includeKeyName 
 				}
 				keys <- prefix
 			} else {
-				for key := range s3wrapper.ListRecurse(b, prefix, searchDepth, true) {
+				for key := range s3wrapper.FastList(b, prefix, searchDepth, true) {
 					if keyRegexFilter != nil && !keyRegexFilter.MatchString(key.Key) {
 						continue
 					}

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate
 	if isRecursive {
 		ch = s3wrapper.ListRecurse(b, prefix, searchDepth)
 	} else {
-		ch = s3wrapper.ListWithCommonPrefixes(b, prefix)
+		ch = s3wrapper.ListWithCommonPrefixes(b, prefix, searchDepth)
 	}
 
 	for k := range ch {

--- a/main.go
+++ b/main.go
@@ -124,9 +124,10 @@ func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate
 	for i := 0; i < runtime.NumCPU(); i++ {
 		wg.Add(1)
 		go func() {
+			writer := bufio.NewWriter(os.Stdout)
 			for k := range ch {
 				if k.Size < 0 {
-					fmt.Printf("%10s s3://%s/%s\n", "DIR", bucket, k.Key)
+					writer.WriteString(fmt.Sprintf("%10s s3://%s/%s\n", "DIR", bucket, k.Key))
 				} else {
 					var size string
 					if isHumanReadable {
@@ -138,9 +139,10 @@ func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate
 					if includeDate {
 						date = " " + k.LastModified
 					}
-					fmt.Printf("%s%s s3://%s/%s\n", size, date, bucket, k.Key)
+					writer.WriteString(fmt.Sprintf("%s%s s3://%s/%s\n", size, date, bucket, k.Key))
 				}
 			}
+			writer.Flush()
 			wg.Done()
 		}()
 	}

--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate
 	var ch <-chan s3.Key
 	ch = s3wrapper.ListRecurse(b, prefix, searchDepth, isRecursive)
 
-	writer := bufio.NewWriter(os.Stdout)
+	writer := bufio.NewWriterSize(os.Stdout, 16384)
 	for k := range ch {
 		if k.Size < 0 {
 			writer.WriteString(fmt.Sprintf("%10s s3://%s/%s\n", "DIR", bucket, k.Key))

--- a/main.go
+++ b/main.go
@@ -118,11 +118,7 @@ func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate
 	b := GetBucket(bucket)
 
 	var ch <-chan s3.Key
-	if isRecursive {
-		ch = s3wrapper.ListRecurse(b, prefix, searchDepth)
-	} else {
-		ch = s3wrapper.ListWithCommonPrefixes(b, prefix, searchDepth)
-	}
+	ch = s3wrapper.ListRecurse(b, prefix, searchDepth, isRecursive)
 
 	for k := range ch {
 		if k.Size < 0 {
@@ -170,7 +166,7 @@ func Del(prefixes []string, searchDepth int, isRecursive bool) {
 				if keyExists {
 					keys <- prefix
 				} else if *delRecurse {
-					for key := range s3wrapper.ListRecurse(b, prefix, searchDepth) {
+					for key := range s3wrapper.ListRecurse(b, prefix, searchDepth, true) {
 						keys <- key.Key
 					}
 
@@ -276,7 +272,7 @@ func Get(prefixes []string, searchDepth int) {
 				ogPrefix := strings.Join(keyParts[0:len(keyParts)-1], "/") + "/"
 				getRequests <- GetRequest{Key: prefix, OriginalPrefix: ogPrefix}
 			} else {
-				for key := range s3wrapper.ListRecurse(b, prefix, searchDepth) {
+				for key := range s3wrapper.ListRecurse(b, prefix, searchDepth, true) {
 					getRequests <- GetRequest{Key: key.Key, OriginalPrefix: prefix}
 				}
 
@@ -363,7 +359,7 @@ func Stream(prefixes []string, searchDepth int, keyRegex string, includeKeyName 
 				}
 				keys <- prefix
 			} else {
-				for key := range s3wrapper.ListRecurse(b, prefix, searchDepth) {
+				for key := range s3wrapper.ListRecurse(b, prefix, searchDepth, true) {
 					if keyRegexFilter != nil && !keyRegexFilter.MatchString(key.Key) {
 						continue
 					}

--- a/main.go
+++ b/main.go
@@ -113,17 +113,16 @@ func GetBucket(bucket string) *s3.Bucket {
 }
 
 // Ls lists directorys or keys under a prefix
-func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate bool) {
+func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate bool, logger *log.Logger) {
 	bucket, prefix := parseS3Uri(s3Uri)
 	b := GetBucket(bucket)
 
 	var ch <-chan s3.Key
 	ch = s3wrapper.ListRecurse(b, prefix, searchDepth, isRecursive)
 
-	writer := bufio.NewWriterSize(os.Stdout, 16384)
 	for k := range ch {
 		if k.Size < 0 {
-			writer.WriteString(fmt.Sprintf("%10s s3://%s/%s\n", "DIR", bucket, k.Key))
+			logger.Printf("%10s s3://%s/%s\n", "DIR", bucket, k.Key)
 		} else {
 			var size string
 			if isHumanReadable {
@@ -135,16 +134,15 @@ func Ls(s3Uri string, searchDepth int, isRecursive, isHumanReadable, includeDate
 			if includeDate {
 				date = " " + k.LastModified
 			}
-			writer.WriteString(fmt.Sprintf("%s%s s3://%s/%s\n", size, date, bucket, k.Key))
+			logger.Printf("%s%s s3://%s/%s\n", size, date, bucket, k.Key)
 		}
 	}
-	writer.Flush()
 }
 
 // Del deletes a set of prefixes(s3 keys or partial keys
-func Del(prefixes []string, searchDepth int, isRecursive bool) {
+func Del(prefixes []string, searchDepth int, isRecursive bool, logger *log.Logger) {
 	if len(*delPrefixes) == 0 {
-		fmt.Printf("No prefixes provided\n Usage: fasts3 del <prefix>")
+		logger.Println("No prefixes provided\n Usage: fasts3 del <prefix>")
 		return
 	}
 	keys := make(chan string, len(prefixes)*2+1)
@@ -172,7 +170,7 @@ func Del(prefixes []string, searchDepth int, isRecursive bool) {
 					}
 
 				} else {
-					fmt.Printf("trying to delete a prefix, please add --recursive or -r to proceed\n")
+					logger.Println("trying to delete a prefix, please add --recursive or -r to proceed")
 				}
 			}
 		}
@@ -216,12 +214,12 @@ func Del(prefixes []string, searchDepth int, isRecursive bool) {
 		close(msgs)
 	}()
 	for msg := range msgs {
-		fmt.Print(msg)
+		logger.Print(msg)
 	}
 }
 
 // initializes configs necessary for fasts3 utility
-func Init() error {
+func Init(logger *log.Logger) error {
 	usr, err := user.Current()
 	if err != nil {
 		return err
@@ -233,9 +231,9 @@ func Init() error {
 access_key=<access_key>
 secret_key=<secret_key>`
 		ioutil.WriteFile(fs3cfg_path, []byte(cfg), 0644)
-		fmt.Printf("created template file %s\n", fs3cfg_path)
+		logger.Printf("created template file %s\n", fs3cfg_path)
 	} else {
-		fmt.Print(".fs3cfg already exists in home directory")
+		logger.Print(".fs3cfg already exists in home directory")
 	}
 
 	return nil
@@ -248,9 +246,9 @@ type GetRequest struct {
 
 // Get lists and retrieves s3 keys given a list of prefixes
 // searchDepth can also be specified to increase speed of listing
-func Get(prefixes []string, searchDepth int) {
+func Get(prefixes []string, searchDepth int, logger *log.Logger) {
 	if len(prefixes) == 0 {
-		fmt.Printf("No prefixes provided\n Usage: fasts3 get <prefix>")
+		logger.Println("No prefixes provided\n Usage: fasts3 get <prefix>")
 		return
 	}
 	getRequests := make(chan GetRequest, len(prefixes)*2+1)
@@ -307,7 +305,7 @@ func Get(prefixes []string, searchDepth int) {
 		close(msgs)
 	}()
 	for msg := range msgs {
-		fmt.Print(msg)
+		logger.Print(msg)
 	}
 }
 
@@ -328,9 +326,9 @@ func getReaderByExt(bts []byte, key string) (*bufio.Reader, error) {
 
 // Stream takes a set of prefixes lists them and
 // streams the contents by line
-func Stream(prefixes []string, searchDepth int, keyRegex string, includeKeyName bool) {
+func Stream(prefixes []string, searchDepth int, keyRegex string, includeKeyName bool, logger *log.Logger) {
 	if len(prefixes) == 0 {
-		fmt.Printf("No prefixes provided\n Usage: fasts3 get <prefix>")
+		logger.Println("No prefixes provided\n Usage: fasts3 get <prefix>\n")
 		return
 	}
 	keys := make(chan string, len(prefixes)*2+1)
@@ -407,22 +405,25 @@ func Stream(prefixes []string, searchDepth int, keyRegex string, includeKeyName 
 		close(msgs)
 	}()
 	for msg := range msgs {
-		fmt.Print(msg)
+		logger.Print(msg)
 	}
 }
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
+	logBuf := bufio.NewWriter(os.Stdout)
+	logger := log.New(logBuf, "", 0)
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
 	case "ls":
-		Ls(*lsS3Uri, *lsSearchDepth, *lsRecurse, *humanReadable, *withDate)
+		Ls(*lsS3Uri, *lsSearchDepth, *lsRecurse, *humanReadable, *withDate, logger)
 	case "del":
-		Del(*delPrefixes, *lsSearchDepth, *delRecurse)
+		Del(*delPrefixes, *lsSearchDepth, *delRecurse, logger)
 	case "get":
-		Get(*getS3Uris, *getSearchDepth)
+		Get(*getS3Uris, *getSearchDepth, logger)
 	case "stream":
-		Stream(*streamS3Uris, *streamSearchDepth, *streamKeyRegex, *streamIncludeKeyName)
+		Stream(*streamS3Uris, *streamSearchDepth, *streamKeyRegex, *streamIncludeKeyName, logger)
 	case "init":
-		Init()
+		Init(logger)
 	}
+	logBuf.Flush()
 }

--- a/s3wrapper/s3.go
+++ b/s3wrapper/s3.go
@@ -45,7 +45,7 @@ func listWorkRecursion(bucket *s3.Bucket, prefix string, currentDepth int, throt
 	throttleChan <- true
 	go func() {
 		if currentDepth == 0 {
-			outChan <- listWork{prefix, "/"}
+			outChan <- listWork{prefix, ""}
 		} else {
 			for res := range List(bucket, prefix, defaultDelimiter) {
 				// catches the case where keys and common prefixes live in the same place

--- a/s3wrapper/s3.go
+++ b/s3wrapper/s3.go
@@ -41,8 +41,8 @@ func StripS3Path(key string) string {
 }
 
 // listWorkRecursion finds all the prefixes under prefix given searchDepth, throttleChan is a channel of booleans which limits the number
-// of go routines to len(throttleChan), outChan is where the output list work is written, finally wg is a WaitGroup which tells the client
-// when the function is complete
+// of go routines to len(throttleChan), outChan is where the output list work is written, wg is a WaitGroup which tells the client
+// when the function is complete, isRecursive tells the lister how to list the prefixes and keys
 func listWorkRecursion(bucket *s3.Bucket, prefix string, searchDepth int, throttleChan chan bool, outChan chan s3.Key, wg *sync.WaitGroup, isRecursive bool) {
 	wg.Add(1)
 	throttleChan <- true
@@ -86,7 +86,7 @@ func listWorkRecursion(bucket *s3.Bucket, prefix string, searchDepth int, thrott
 
 // getListWork generates a list of prefixes based on prefix by searching down the searchDepth
 // using DELIMITER as a delimiter
-func ListRecurse(bucket *s3.Bucket, prefix string, searchDepth int, isRecursive bool) chan s3.Key {
+func FastList(bucket *s3.Bucket, prefix string, searchDepth int, isRecursive bool) chan s3.Key {
 	results := make(chan s3.Key, 100000)
 	throttleChan := make(chan bool, numListRoutines)
 	var wg sync.WaitGroup

--- a/s3wrapper/s3.go
+++ b/s3wrapper/s3.go
@@ -84,8 +84,9 @@ func listWorkRecursion(bucket *s3.Bucket, prefix string, searchDepth int, thrott
 	}()
 }
 
-// getListWork generates a list of prefixes based on prefix by searching down the searchDepth
-// using DELIMITER as a delimiter
+// FastList does a recursive threaded operation to generate a list of prefixes based on prefix
+// by searching down the searchDepth using DELIMITER as a delimiter and isRecursive to tell
+// whether or not to use a delimiter when listing
 func FastList(bucket *s3.Bucket, prefix string, searchDepth int, isRecursive bool) chan s3.Key {
 	results := make(chan s3.Key, 100000)
 	throttleChan := make(chan bool, numListRoutines)


### PR DESCRIPTION
* got rid of ListRecurse and ListWithCommonPrefixes as they were just doing more work than necessary
* use log.Logger instead of fmt.Print for output