### PR TITLE
Unescape s3 keys

### DIFF
--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func Rm(svc *s3.S3, s3Uris []string, recurse bool, delimiter string, searchDepth
 }
 
 func main() {
-	app.Version("1.3.1")
+	app.Version("1.3.2")
 	aws_session, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})


### PR DESCRIPTION
    keys come in URL escaped (e.g. "$" becomes "%24"), this is problematic
    for other operations such as delete and copy when they run into these
    encodings because it does not match the key and will not do the
    operation. Thus we need to escape the keys coming from AWS' API
