### PR TITLE
allow output from stream to be raw and ordered. 

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func Rm(svc *s3.S3, s3Uris []string, recurse bool, delimiter string, searchDepth
 }
 
 func main() {
-	app.Version("1.3.1")
+	app.Version("1.3.2")
 	aws_session, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})

--- a/s3wrapper/s3.go
+++ b/s3wrapper/s3.go
@@ -184,7 +184,7 @@ func (w *S3Wrapper) Stream(keys chan *ListOutput, includeKeyName bool, raw bool)
 					bufExtReader := bufio.NewReader(extReader)
 
 					for {
-						line, _, err := bufExtReader.ReadLine()
+						line, err := bufExtReader.ReadBytes('\n')
 
 						if err != nil && err.Error() != "EOF" {
 							log.Fatalln(err)

--- a/s3wrapper/s3.go
+++ b/s3wrapper/s3.go
@@ -181,10 +181,10 @@ func (w *S3Wrapper) Stream(keys chan *ListOutput, includeKeyName bool, raw bool)
 				defer func() { <-w.concurrencySemaphore }()
 
 				reader, err := w.GetReader(*key.Bucket, *key.Key)
-				defer reader.Close()
 				if err != nil {
 					panic(err)
 				}
+				defer reader.Close()
 				if !raw {
 					extReader, err := util.GetReaderByExt(reader, *key.Key)
 					if err != nil {
@@ -202,7 +202,7 @@ func (w *S3Wrapper) Stream(keys chan *ListOutput, includeKeyName bool, raw bool)
 						if includeKeyName {
 							lines <- fmt.Sprintf("[%s] %s", *key.FullKey, string(line))
 						} else {
-							lines <- fmt.Sprintf("%s", string(line))
+							lines <- string(line)
 						}
 						if err != nil {
 							break
@@ -219,7 +219,7 @@ func (w *S3Wrapper) Stream(keys chan *ListOutput, includeKeyName bool, raw bool)
 						if includeKeyName {
 							lines <- fmt.Sprintf("[%s] %s", *key.FullKey, string(buf[0:numBytes]))
 						} else {
-							lines <- fmt.Sprintf("%s", string(buf[0:numBytes]))
+							lines <- string(buf[0:numBytes])
 						}
 
 						if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"bufio"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -53,16 +52,16 @@ func GetNumFileDescriptors() (uint64, error) {
 }
 
 // getReaderByExt is a factory for reader based on the extension of the key
-func GetReaderByExt(reader io.ReadCloser, key string) (*bufio.Reader, error) {
+func GetReaderByExt(reader io.ReadCloser, key string) (io.ReadCloser, error) {
 	ext := path.Ext(key)
 	if ext == ".gz" || ext == ".gzip" {
 		gzReader, err := gzip.NewReader(reader)
 		if err != nil {
-			return bufio.NewReader(reader), nil
+			return reader, nil
 		}
-		return bufio.NewReader(gzReader), nil
+		return gzReader, nil
 	} else {
-		return bufio.NewReader(reader), nil
+		return reader, nil
 	}
 }
 


### PR DESCRIPTION
By default all output from the `stream` command comes line-delimited and un-ordered.
Using raw bypasses automatic unzipping of gz files and doesn't output bytes delimited by newlines, but 64
byte chunks of the key. Ordered ensures output from different S3
keys are not inter-mingled, useful when trying to look at a sequence
of events in log files or to maintain a continuous set of bytes from
a binary file.

fixes #30 